### PR TITLE
Removing cases where assumptions are not embedded within a @cl, and other minor changes.

### DIFF
--- a/signature/alethe.eo
+++ b/signature/alethe.eo
@@ -813,75 +813,134 @@
 ;---------------
 ; Rule 24: cong
 ;---------------
-(program $check_cong ((premises Bool) (conclusion Bool) (A Type) (B Type)
-                      (arg_l A) (arg_r A)
-                      (args_l A :list) (args_r A :list) (fl_binary (-> A A B)) (fr_binary (-> A A B))
-                      (lhs A) (rhs A))
+; program: $mk_variadic_cong_rhs
+; args:
+; - U Type:
+; - f ->:
+; - s1 U:
+; - s2 U:
+; - t U:
+; - tail Bool:
+; - nil U:
+; note: >
+;   Taken from CPC's Eunoia mechanization: 
+;   https://github.com/cvc5/cvc5/blob/main/proofs/eo/cpc/rules/Uf.eo
+; return:
+(program $mk_variadic_cong_rhs ((U Type) (f (-> U U U)) (s1 U) (s2 U) (t U :list) (tail Bool :list) (nil U))
+    :signature (U Bool) U
+    (
+        (; TODO: remove this once we deal with embedding assumptions into
+         ; @cl
+         ($mk_variadic_cong_rhs (f s1 t) (and (= s1 s2) tail))  
+
+         (eo::cons f s2 ($mk_variadic_cong_rhs t tail))
+         )
+
+        (
+         ($mk_variadic_cong_rhs (f s1 t) (and (@cl (= s1 s2)) tail))  
+
+         (eo::cons f s2 ($mk_variadic_cong_rhs t tail))
+         )
+
+        (
+         ($mk_variadic_cong_rhs nil true)                       
+
+         nil)
+    )
+)
+
+; program: $mk_nary_cong_rhs
+; args:
+; - T Type:
+; - U Type:
+; - f ->:
+; - t1 U:
+; - t2 U:
+; - t3 U:
+; - tail Bool:
+; return:
+(program $mk_nary_cong_rhs ((T Type) (U Type) (f (-> T U)) (t1 U) (t2 U) (t3 U) (tail Bool :list))
+    :signature (U Bool) U
+    (
+        (
+         ($mk_nary_cong_rhs (f t1) (and (= t1 t2) tail))  
+
+         (_ ($mk_nary_cong_rhs f tail) t2)
+         )
+
+        (; TODO: remove this case
+         ($mk_nary_cong_rhs (f t1) (and (@cl (= t1 t2)) tail))
+
+         (_ ($mk_nary_cong_rhs f tail) t2)
+         )
+
+        (
+         ($mk_nary_cong_rhs f true)                       
+         
+         f
+         )
+    )
+)
+
+; program: $check_cong_nary
+; args:
+; - premises Bool:
+; - A Type:
+; - lhs A:
+; - rhs A:
+; return:
+(program $check_cong_nary ((premises Bool) (A Type) (lhs A) (rhs A))
   (Bool Bool) Bool
   (
    (
-    ($check_cong true conclusion)
+    ($check_cong_nary premises (@cl (= lhs rhs)))
 
-    true
-    )
-
-   (
-    ($check_cong premises (@cl (= (fl_binary arg_l args_l) (fr_binary arg_r args_r))))
-
-    (@cl premises 
-
-         (@cl (= (fl_binary arg_l args_l) (fr_binary arg_r args_r)))
-
-         (@cl (= ($f_list_last_element fl_binary (fl_binary arg_l args_l)) 
-                 ($f_list_last_element fr_binary (fr_binary arg_r args_r))))
-
-         ($f_list_last_element and premises)
-
-         ($f_list_equal @cl (@cl (= ($f_list_last_element fl_binary (fl_binary arg_l args_l)) 
-                                    ($f_list_last_element fr_binary (fr_binary arg_r args_r))))
-                        ($f_list_last_element and premises))
-
-         ($f_list_remove_elem and premises
-                                       (@cl (= ($f_list_last_element fl_binary (fl_binary arg_l args_l)) 
-                                               ($f_list_last_element fr_binary (fr_binary arg_r args_r)))) true)
-
-         (@cl (= ($f_list_remove_elem fl_binary (fl_binary arg_l args_l) 
-                                      ($f_list_last_element fl_binary (fl_binary arg_l args_l)) true)
-                 ($f_list_remove_elem fr_binary (fr_binary arg_r args_r)
-                                      ($f_list_last_element fr_binary (fr_binary arg_r args_r)) true)))
-              
-     ($check_cong ($f_list_remove_elem and premises
-                                       (@cl (= ($f_list_last_element fl_binary (fl_binary arg_l args_l)) 
-                                               ($f_list_last_element fr_binary (fr_binary arg_r args_r)))) true)
-                  (@cl (= ($f_list_remove_elem fl_binary (fl_binary arg_l args_l) 
-                                               ($f_list_last_element fl_binary (fl_binary arg_l args_l)) true)
-                          ($f_list_remove_elem fr_binary (fr_binary arg_r args_r)
-                                               ($f_list_last_element fr_binary (fr_binary arg_r args_r)) true))))
-         )
-    
-    ;; (eo::and
-    ;;  ; Check last premise
-    ;;  ($f_list_equal @cl (@cl (= ($f_list_last_element fl_binary (fl_binary arg_l args_l)) 
-    ;;                             ($f_list_last_element fr_binary (fr_binary arg_r args_r))))
-    ;;                 ($f_list_last_element and premises))
-     
-    ;;  ; Check remaining premises
-    ;;  ($check_cong ($f_list_remove_elem and premises
-    ;;                                    (@cl (= ($f_list_last_element fl_binary (fl_binary arg_l args_l)) 
-    ;;                                            ($f_list_last_element fr_binary (fr_binary arg_r args_r)))) true)
-    ;;               (@cl (= ($f_list_remove_elem fl_binary (fl_binary arg_l args_l) 
-    ;;                                            ($f_list_last_element fl_binary (fl_binary arg_l args_l)) true)
-    ;;                       ($f_list_remove_elem fr_binary (fr_binary arg_r args_r)
-    ;;                                            ($f_list_last_element fr_binary (fr_binary arg_r args_r)) true))))
-    ;;  )
+    ($f_list_equal = ($mk_nary_cong_rhs lhs (eo::list_rev and premises)) rhs)
     )
    )
-  )
+)
 
-;TRUST
-(declare-rule cong ((premises Bool))
+; program: $check_cong_variadic
+; args:
+; - premises Bool:
+; - A Type:
+; - lhs A:
+; - rhs A:
+; return:
+(program $check_cong_variadic ((premises Bool) (A Type) (lhs A) (rhs A))
+  (Bool Bool) Bool
+  (
+   (
+    ($check_cong_variadic premises (@cl (= lhs rhs)))
+
+    ($f_list_equal = ($mk_variadic_cong_rhs lhs premises) rhs)
+    )
+   )
+)
+
+; rule: cong_nary
+; implements: TODO?
+; premises:
+; - premises Bool:
+; args:
+; requires:
+; conclusion:
+(declare-rule cong_nary ((premises Bool))
   :premise-list premises and
-  :requires ((($check_cong premises eo::conclusion) true))
+  :requires ((($check_cong_nary premises eo::conclusion) true))
+  :conclusion-given
+)
+
+; rule: cong_variadic
+; implements: TODO?
+; premises:
+; - premises Bool:
+; args:
+; requires:
+; conclusion:
+(declare-rule cong_variadic ((premises Bool))
+  :premise-list premises and
+  :requires ((($check_cong_variadic premises eo::conclusion) true))
   :conclusion-given
 )
 

--- a/signature/alethe.eo
+++ b/signature/alethe.eo
@@ -813,134 +813,176 @@
 ;---------------
 ; Rule 24: cong
 ;---------------
-; program: $mk_variadic_cong_rhs
+
+; program: $check_list_left_assoc
 ; args:
-; - U Type:
-; - f ->:
-; - s1 U:
-; - s2 U:
-; - t U:
-; - tail Bool:
-; - nil U:
-; note: >
-;   Taken from CPC's Eunoia mechanization: 
-;   https://github.com/cvc5/cvc5/blob/main/proofs/eo/cpc/rules/Uf.eo
+; - lhs U: LHS of the equality in the conclusion passed to the cong rule.
+; - rhs U: RHS of the equality in the conclusion passed to the cong rule.
+; - premises Bool: Premises passed to the cong rule, but in the reverse order.
 ; return:
-(program $mk_variadic_cong_rhs ((U Type) (f (-> U U U)) (s1 U) (s2 U) (t U :list) (tail Bool :list) (nil U))
-    :signature (U Bool) U
+(program $check_list_left_assoc ((T Type) (U Type) 
+                                          (f (-> T U U)) (f2 (-> T U U)) (t1 T) (t2 T) 
+                                          (lhs U) (rhs U) (tail Bool :list) (premises Bool))
+    :signature (U U Bool) U
     (
-        (; TODO: remove this once we deal with embedding assumptions into
-         ; @cl
-         ($mk_variadic_cong_rhs (f s1 t) (and (= s1 s2) tail))  
+     (; TODO: why?
+      ($check_list_left_assoc (f t1) (f t2) (and (= t1 t2)))
 
-         (eo::cons f s2 ($mk_variadic_cong_rhs t tail))
-         )
+      true
+      )
 
-        (
-         ($mk_variadic_cong_rhs (f s1 t) (and (@cl (= s1 s2)) tail))  
+     (
+      ($check_list_left_assoc (f t1) (f t2) (and (@cl (= t1 t2))))
 
-         (eo::cons f s2 ($mk_variadic_cong_rhs t tail))
-         )
+      true
+      )
 
-        (
-         ($mk_variadic_cong_rhs nil true)                       
+     ( ; TODO: ill-typed
+      ($check_list_left_assoc (f t1) (f2 t2) (and (@cl (= t1 t2)) tail))
 
-         nil)
+      ($check_list_left_assoc f f2 tail)
+      )
+
+     (; TODO: why?
+      ($check_list_left_assoc (f t1) (f2 t2) (and (= t1 t2) tail))
+
+      ($check_list_left_assoc f f2 tail)
+      )
+
+     (; We need for $check_list_left_assoc to be a total function.
+      ($check_list_left_assoc lhs rhs premises)
+
+      false
+      )
+     )
     )
-)
 
-; program: $mk_nary_cong_rhs
+; program: $check_list_right_assoc
 ; args:
-; - T Type:
-; - U Type:
-; - f ->:
-; - t1 U:
-; - t2 U:
-; - t3 U:
-; - tail Bool:
+; - lhs U: LHS of the equality, in the conclusion.
+; - rhs U: RHS of the equality, in the conclusion.
+; - rev_premises Bool: Premises given to the cong rule.
 ; return:
-(program $mk_nary_cong_rhs ((T Type) (U Type) (f (-> T U)) (t1 U) (t2 U) (t3 U) (tail Bool :list))
-    :signature (U Bool) U
+(program $check_list_right_assoc ((T Type) (U Type) (f (-> T U U)) 
+                                           (f2 (-> T U U)) (t1 T) (t2 T) (t3 T) (t4 T) (lhs U :list) (rhs U :list) 
+                                           (premises Bool) (tail Bool :list))
+    :signature (U U Bool) U
     (
-        (
-         ($mk_nary_cong_rhs (f t1) (and (= t1 t2) tail))  
+     (; TODO: why?
+      ($check_list_right_assoc (f t1) (f t2) (and (= t1 t2)))
 
-         (_ ($mk_nary_cong_rhs f tail) t2)
-         )
+      true
+      )
 
-        (; TODO: remove this case
-         ($mk_nary_cong_rhs (f t1) (and (@cl (= t1 t2)) tail))
+     (
+      ($check_list_right_assoc (f t1) (f t2) (and (@cl (= t1 t2))))
 
-         (_ ($mk_nary_cong_rhs f tail) t2)
-         )
+      true
+      )
 
-        (
-         ($mk_nary_cong_rhs f true)                       
-         
-         f
-         )
+     (
+      ($check_list_right_assoc t1 t2 (and (@cl (= t1 t2))))
+
+      true
+      )
+
+     (
+      ($check_list_right_assoc t1 t2 (and (= t1 t2)))
+
+      true
+      )
+
+     (
+      ($check_list_right_assoc f f tail)
+
+      true
+      )
+
+     (
+      ($check_list_right_assoc (f t1) (f t2) (and (= t1 t2) tail))
+
+      true
+      )
+
+     (
+      ($check_list_right_assoc (f t1) (f t2) (and (@cl (= t1 t2)) tail))
+      true
+      )
+
+     ( ; TODO: ill-typed
+      ($check_list_right_assoc (f t1 lhs) (f t2 rhs) (and (@cl (= t1 t2)) tail))
+
+      ($check_list_right_assoc lhs rhs tail)
+      )
+
+     ( ; TODO: ill-typed
+      ($check_list_right_assoc (f t1 lhs) (f t2 rhs) (and (= t1 t2) tail))
+
+      ($check_list_right_assoc lhs rhs tail)
+      )
+
+     ( ; We need for $check_list_right_assoc to be total 
+      ($check_list_right_assoc lhs rhs premises)
+
+      false
+      )
+     )
     )
-)
 
-; program: $check_cong_nary
+; program: $check_cong
 ; args:
-; - premises Bool:
-; - A Type:
-; - lhs A:
-; - rhs A:
-; return:
-(program $check_cong_nary ((premises Bool) (A Type) (lhs A) (rhs A))
+; - premises Bool: >
+;   Premises given to rule cong. Must be an and-list of each premise (equality).
+; - conclusion Bool: Conclusion clause given to rule cong.
+; return: >
+;   A boolean indicating if "conclusion" follows from the and-list of premises
+;   given.
+(program $check_cong ((U Type) (lhs U :list) (rhs U :list) (premises Bool))
   (Bool Bool) Bool
   (
    (
-    ($check_cong_nary premises (@cl (= lhs rhs)))
+    ($check_cong premises (@cl (= lhs rhs)))
+    
+    (eo::ite ($is_f_list lhs)
+             ; We need to distinguish: 
+             ; - n-ary from variadic operators
+             ; - left-assoc from right-assoc: 
+             ;    - since we do not have effective means to do this, we try to check
+             ;       the rule in both ways: as if the f applied were right-assoc, 
+             ;       and if it were left-assoc.
+             (eo::or 
 
-    ($f_list_equal = ($mk_nary_cong_rhs lhs (eo::list_rev and premises)) rhs)
+              ($check_list_right_assoc
+               ($f_list_remove_nil_terminator lhs) 
+               ($f_list_remove_nil_terminator rhs)
+               premises)
+
+              ($check_list_left_assoc 
+               ($f_list_remove_nil_terminator lhs) 
+               ($f_list_remove_nil_terminator rhs)
+               (eo::list_rev and premises)))
+
+             (eo::or 
+
+              ($check_list_right_assoc lhs rhs premises)
+
+              ($check_list_left_assoc lhs rhs (eo::list_rev and premises)))
+             )
     )
    )
 )
 
-; program: $check_cong_variadic
-; args:
-; - premises Bool:
-; - A Type:
-; - lhs A:
-; - rhs A:
-; return:
-(program $check_cong_variadic ((premises Bool) (A Type) (lhs A) (rhs A))
-  (Bool Bool) Bool
-  (
-   (
-    ($check_cong_variadic premises (@cl (= lhs rhs)))
-
-    ($f_list_equal = ($mk_variadic_cong_rhs lhs premises) rhs)
-    )
-   )
-)
-
-; rule: cong_nary
+; rule: cong
 ; implements: TODO?
 ; premises:
-; - premises Bool:
-; args:
-; requires:
-; conclusion:
-(declare-rule cong_nary ((premises Bool))
+; - premises Bool: An and-list of premises of the form t1 = u1, ..., tm = um.
+; requires: >
+;   For "conclusion" to be of the form:
+;   f s1 ... sn = f s1 ... sn t1 ... tm = f s1 ... sn = f s1 ... sn u1 ... um
+; conclusion-given: 
+(declare-rule cong ((premises Bool))
   :premise-list premises and
-  :requires ((($check_cong_nary premises eo::conclusion) true))
-  :conclusion-given
-)
-
-; rule: cong_variadic
-; implements: TODO?
-; premises:
-; - premises Bool:
-; args:
-; requires:
-; conclusion:
-(declare-rule cong_variadic ((premises Bool))
-  :premise-list premises and
-  :requires ((($check_cong_variadic premises eo::conclusion) true))
+  :requires ((($check_cong premises eo::conclusion) true))
   :conclusion-given
 )
 

--- a/signature/alethe.eo
+++ b/signature/alethe.eo
@@ -822,7 +822,9 @@
 ; - premises Bool: Premises passed to the cong rule, but in the reverse order.
 ; return: >
 ;    A boolean indicating if lhs, rhs and premises correspond to the proper
-;    application of the cong rule, for a left-assoc operator.
+;    application of the cong rule, for a n-ary operator. Note that, in this case,
+;    we are dealing with the single application of a n-ary operator. No 
+;    associativity is involved.
 (program $check_n_ary_application ((T Type) (U Type) 
                                           (f (-> T U U)) (f2 (-> T U U)) (t1 T) (t2 T) (t3 T)
                                           (lhs U) (rhs U) (tail Bool :list) (premises Bool))

--- a/signature/alethe.eo
+++ b/signature/alethe.eo
@@ -151,7 +151,7 @@
 
 ; program: $check_subproof
 ; args:
-; - assumption Bool: Assumption passed to "subproof", not built with @cl.
+; - assumption Bool: Assumption passed to "subproof".
 ; - premise Bool: Last step before the application of "subproof".
 ; - conclusion Bool: Conclusion of the "subproof" step.
 ; return: >
@@ -162,7 +162,7 @@
   (Bool Bool Bool) Bool
   (
    (
-    ($check_subproof assumption @empty_cl conclusion)
+    ($check_subproof (@cl assumption) @empty_cl conclusion)
 
     (eo::and
      ($f_list_contains_elem @cl (not assumption) conclusion)
@@ -171,7 +171,7 @@
     )
 
    (; { premise =/= @empty_cl }
-    ($check_subproof assumption premise conclusion)
+    ($check_subproof (@cl assumption) premise conclusion)
 
     (eo::and
      ($f_list_contains_elem @cl (not assumption) conclusion)
@@ -180,15 +180,16 @@
   )
 )
 
-;TODO: test if the list here works well
 ; rule: subproof
 ; implements: TODO?
 ; assumption:
-; - assumption Bool: Assumption passed to "subproof", not built with @cl.
+; - assumption Bool: Assumption passed to "subproof".
 ; premises:
 ; - premise Bool: Last step before the application of "subproof".
 ; requires: >
 ;   For conclusion to be of the form (@cl (not assumption) premise).
+;   Note that, for the cases where we have more than 1 assumption,
+;   rule subproof is applied stepwise, discharging 1 assumption at a time.
 ; conclusion-given: >
 ;  Only the "requires" predicate checks if a proper conclusion is given.
 (declare-rule subproof ((assumption Bool) (premise Bool))
@@ -814,117 +815,137 @@
 ; Rule 24: cong
 ;---------------
 
-; program: $check_list_left_assoc
+; program: $check_n_ary_application
 ; args:
 ; - lhs U: LHS of the equality in the conclusion passed to the cong rule.
 ; - rhs U: RHS of the equality in the conclusion passed to the cong rule.
 ; - premises Bool: Premises passed to the cong rule, but in the reverse order.
-; return:
-(program $check_list_left_assoc ((T Type) (U Type) 
-                                          (f (-> T U U)) (f2 (-> T U U)) (t1 T) (t2 T) 
+; return: >
+;    A boolean indicating if lhs, rhs and premises correspond to the proper
+;    application of the cong rule, for a left-assoc operator.
+(program $check_n_ary_application ((T Type) (U Type) 
+                                          (f (-> T U U)) (f2 (-> T U U)) (t1 T) (t2 T) (t3 T)
                                           (lhs U) (rhs U) (tail Bool :list) (premises Bool))
-    :signature (U U Bool) U
+    :signature (U U Bool) Bool
     (
-     (; TODO: why?
-      ($check_list_left_assoc (f t1) (f t2) (and (= t1 t2)))
-
-      true
-      )
-
      (
-      ($check_list_left_assoc (f t1) (f t2) (and (@cl (= t1 t2))))
+      ($check_n_ary_application (f t1) (f t2) (and (@cl (= t1 t2))))
 
       true
       )
 
-     ( ; TODO: ill-typed
-      ($check_list_left_assoc (f t1) (f2 t2) (and (@cl (= t1 t2)) tail))
+     ( ; TODO: ill-typed?
+      ($check_n_ary_application (f t1) (f2 t2) (and (@cl (= t1 t2)) tail))
 
-      ($check_list_left_assoc f f2 tail)
+      ($check_n_ary_application f f2 tail)
       )
+     
+     ( ; Rule cong allows for the premises to not include the cases of reflexive 
+       ; equalities. We treat that here.
+      ($check_n_ary_application (f t1) (f2 t1) (and (@cl (= t2 t3)) tail))
 
-     (; TODO: why?
-      ($check_list_left_assoc (f t1) (f2 t2) (and (= t1 t2) tail))
-
-      ($check_list_left_assoc f f2 tail)
-      )
-
-     (; We need for $check_list_left_assoc to be a total function.
-      ($check_list_left_assoc lhs rhs premises)
-
-      false
+      ($check_n_ary_application f f2 (and (@cl (= t2 t3)) tail))
       )
      )
     )
 
-; program: $check_list_right_assoc
+; program: $check_variadic_left_assoc
+; args:
+; - lhs U: LHS of the equality in the conclusion passed to the cong rule.
+; - rhs U: RHS of the equality in the conclusion passed to the cong rule.
+; - premises Bool: Premises passed to the cong rule, but in the reverse order.
+; return: >
+;    A boolean indicating if lhs, rhs and premises correspond to the proper
+;    application of the cong rule, for a left-assoc operator.
+(program $check_variadic_left_assoc ((T Type) (U Type) 
+                                          (f (-> T U U)) (f2 (-> T U U)) (t1 T) (t2 T) (t3 T)
+                                          (lhs U) (rhs U) (tail Bool :list) (premises Bool))
+    :signature (U U Bool) Bool
+    (
+     (; This case covers the situation where f is actually
+      ; the original variadic operator being applied to its nil
+      ; value, as it would be the case for a left-assoc-nil op.
+      ($check_variadic_left_assoc (f t1) (f t2) (and (@cl (= t1 t2))))
+
+      true
+      )
+
+     ( ; TODO: ill-typed?
+      ($check_variadic_left_assoc (f t1) (f2 t2) (and (@cl (= t1 t2)) tail))
+
+      ($check_variadic_left_assoc f f2 tail)
+      )
+
+     (; Rule cong allows for the premises to not include the cases of reflexive 
+      ; equalities. We treat that here.
+      ($check_variadic_left_assoc (f t1) (f2 t1) (and (@cl (= t2 t3)) tail))
+
+      ($check_variadic_left_assoc f f2 (and (@cl (= t2 t3)) tail))
+      )
+     )
+    )
+
+; program: $check_variadic_right_assoc
 ; args:
 ; - lhs U: LHS of the equality, in the conclusion.
 ; - rhs U: RHS of the equality, in the conclusion.
 ; - rev_premises Bool: Premises given to the cong rule.
 ; return:
-(program $check_list_right_assoc ((T Type) (U Type) (f (-> T U U)) 
-                                           (f2 (-> T U U)) (t1 T) (t2 T) (t3 T) (t4 T) (lhs U :list) (rhs U :list) 
+(program $check_variadic_right_assoc ((T Type) (U Type) (f (-> T U U)) 
+                                           (f2 (-> T U U)) (t1 T) (t2 T) (t3 T) (nil U :list) (lhs U :list) (rhs U :list)
                                            (premises Bool) (tail Bool :list))
-    :signature (U U Bool) U
+    :signature (U U Bool) Bool
     (
-     (; TODO: why?
-      ($check_list_right_assoc (f t1) (f t2) (and (= t1 t2)))
+     (; Ending of both f-lists
+      ($check_variadic_right_assoc (f t1 nil) (f t2 nil) (and (@cl (= t1 t2))))
 
-      true
-      )
-
-     (
-      ($check_list_right_assoc (f t1) (f t2) (and (@cl (= t1 t2))))
-
-      true
-      )
-
-     (
-      ($check_list_right_assoc t1 t2 (and (@cl (= t1 t2))))
-
-      true
-      )
-
-     (
-      ($check_list_right_assoc t1 t2 (and (= t1 t2)))
-
-      true
-      )
-
-     (
-      ($check_list_right_assoc f f tail)
-
-      true
-      )
-
-     (
-      ($check_list_right_assoc (f t1) (f t2) (and (= t1 t2) tail))
-
-      true
-      )
-
-     (
-      ($check_list_right_assoc (f t1) (f t2) (and (@cl (= t1 t2)) tail))
       true
       )
 
      ( ; TODO: ill-typed
-      ($check_list_right_assoc (f t1 lhs) (f t2 rhs) (and (@cl (= t1 t2)) tail))
+      ($check_variadic_right_assoc (f t1 lhs) (f t2 rhs) (and (@cl (= t1 t2)) tail))
 
-      ($check_list_right_assoc lhs rhs tail)
+      ($check_variadic_right_assoc lhs rhs tail)
       )
 
-     ( ; TODO: ill-typed
-      ($check_list_right_assoc (f t1 lhs) (f t2 rhs) (and (= t1 t2) tail))
+     (; Rule cong allows for the premises to not include the cases of reflexive 
+      ; equalities. We treat that here.
+      ($check_variadic_right_assoc (f t1 lhs) (f t1 rhs) (and (@cl (= t2 t3)) tail))
 
-      ($check_list_right_assoc lhs rhs tail)
+      ($check_variadic_right_assoc lhs rhs (and (@cl (= t2 t3)) tail))
+      )
+     )
+    )
+
+; program: $cong_extract_operator
+; args:
+; - lhs (-> T U) : >
+;    The left-hand side of the conclusion given to the cong rule, where the last argument
+;    of the function application has been removed. This is so for typing purposes.
+; - rhs (-> T U) : >
+;    The right-hand side of the conclusion given to the cong rule, where the last argument
+;    of the function application has been removed. This is so for typing purposes.
+; return: >
+;    If both sides contain the same function being applied, 
+;    $cong_extract_operator returns it.
+(program $cong_extract_operator ((T Type) (U Type)
+                                 (lhs_f (-> T U)) (rhs_f (-> T U)) (lhs U) (rhs U))
+    :signature ((-> T U) (-> T U)) (-> T U)
+    (
+     (; I can type lhs_f and rhs_f as being unary, because of currying.
+      ; This matches, regardless of the associativity of the operators involved.
+      ($cong_extract_operator (lhs_f lhs) (rhs_f rhs))
+      ; Since the expected type of the parameters is (-> T U), it contemplates the case
+      ; where lhs_f and rhs_f are not actual unary functions.
+      ($cong_extract_operator lhs_f rhs_f)
       )
 
-     ( ; We need for $check_list_right_assoc to be total 
-      ($check_list_right_assoc lhs rhs premises)
+     (; We cannot decompose the parameters received as an application of some
+      ; unary function: we must have reached to the function itself, and lhs and rhs
+      ; should contain the same function.
+      ($cong_extract_operator lhs_f lhs_f)
 
-      false
+      lhs_f
       )
      )
     )
@@ -937,37 +958,31 @@
 ; return: >
 ;   A boolean indicating if "conclusion" follows from the and-list of premises
 ;   given.
-(program $check_cong ((U Type) (lhs U :list) (rhs U :list) (premises Bool))
+(program $check_cong ((T Type) (U Type) (f_lhs (-> T U)) (lhs U) (f_rhs (-> T U)) (rhs U) 
+                      (premises Bool))
   (Bool Bool) Bool
   (
    (
-    ($check_cong premises (@cl (= lhs rhs)))
-    
-    (eo::ite ($is_f_list lhs)
-             ; We need to distinguish: 
-             ; - n-ary from variadic operators
-             ; - left-assoc from right-assoc: 
-             ;    - since we do not have effective means to do this, we try to check
-             ;       the rule in both ways: as if the f applied were right-assoc, 
-             ;       and if it were left-assoc.
-             (eo::or 
+    ($check_cong premises (@cl (= (f_lhs lhs) (f_rhs rhs))))
+    (eo::define ((operator ($cong_extract_operator f_lhs f_rhs)))
+                (eo::ite ($is_theory_f_list operator)
+                         ; Operator is variadic. It must be left or right assoc.
+                         (eo::ite ($is_theory_op_left_assoc operator)
+                                  ($check_variadic_left_assoc (f_lhs lhs) (f_rhs rhs)
+                                                              (eo::list_rev and premises))
 
-              ($check_list_right_assoc
-               ($f_list_remove_nil_terminator lhs) 
-               ($f_list_remove_nil_terminator rhs)
-               premises)
-
-              ($check_list_left_assoc 
-               ($f_list_remove_nil_terminator lhs) 
-               ($f_list_remove_nil_terminator rhs)
-               (eo::list_rev and premises)))
-
-             (eo::or 
-
-              ($check_list_right_assoc lhs rhs premises)
-
-              ($check_list_left_assoc lhs rhs (eo::list_rev and premises)))
-             )
+                                  ; { not ($is_theory_op_left_assoc operator) }
+                                  ($check_variadic_right_assoc (f_lhs lhs) (f_rhs rhs)
+                                                               premises)
+                                  )
+                         
+                         ; { not ($is_theory_f_list operator) }
+                         ; For the single application of a n-ary operator, there is no associativity
+                         ; involved. We do not need to distinguish among left/righ assoc. or no assoc.
+                         ; at all.
+                         ; Note that every user defined function constant ends up being n-ary.
+                         ($check_n_ary_application (f_lhs lhs) (f_rhs rhs) (eo::list_rev and premises)))
+                )
     )
    )
 )
@@ -978,7 +993,9 @@
 ; - premises Bool: An and-list of premises of the form t1 = u1, ..., tm = um.
 ; requires: >
 ;   For "conclusion" to be of the form:
-;   f s1 ... sn = f s1 ... sn t1 ... tm = f s1 ... sn = f s1 ... sn u1 ... um
+;   f s1 ... sn t1 ... tm = f s1 ... sn u1 ... um
+;   with premises: 
+;   t1 = u1, ..., tm = um.
 ; conclusion-given: 
 (declare-rule cong ((premises Bool))
   :premise-list premises and

--- a/signature/alethe.eo
+++ b/signature/alethe.eo
@@ -45,8 +45,17 @@
 (program $check_not_not ((phi Bool))
     (Bool) Bool
     (
-    (($check_not_not (@cl (not (not (not phi))) phi)) true)
-    (($check_not_not (@cl phi (not (not (not phi))))) true)
+    (
+     ($check_not_not (@cl (not (not (not phi))) phi))
+     
+     true
+     )
+
+    (
+     ($check_not_not (@cl phi (not (not (not phi)))))
+     
+     true
+     )
     )
 )
 
@@ -702,30 +711,6 @@
     
     (= t2 ($last_eq_right eqs t1))
     )
-
-   (; case (and (= t1 t2) true)
-    ($make_trans (and (= t1 t2)) t1) 
-    
-    (= t1 t2)
-    )
-
-   (; case (and (= t1 t2) true)
-    ($make_trans (and (= t1 t2)) t2) 
-    
-    (= t1 t2)
-    )
-
-   (; { eqs <> true }
-    ($make_trans (and (= t1 t2) eqs) t1) 
-    
-    (= t1 ($last_eq_right eqs t2))
-    )
-
-   (; { eqs <> true }
-    ($make_trans (and (= t1 t2) eqs) t2) 
-    
-    (= t2 ($last_eq_right eqs t1))
-    )
   )
 )
 
@@ -766,30 +751,6 @@
     ($check_trans (and (@cl (= lhs_1 rhs)) eqs) (@cl (= lhs_2 rhs)))
 
     ($f_list_equal = ($make_trans (and (@cl (= lhs_1 rhs)) eqs) rhs) (= lhs_2 rhs))
-    )
-
-   (
-    ($check_trans (and (= lhs rhs)) (@cl (= lhs rhs)))
-    
-    true
-    )
-
-   (
-    ($check_trans (and (= lhs rhs)) (@cl (= rhs lhs)))
-    
-    true
-    )
-
-   (
-    ($check_trans (and (= lhs rhs_2) eqs) (@cl (= lhs rhs_1)))
-
-    ($f_list_equal = ($make_trans (and (= lhs rhs_2) eqs) lhs) (= lhs rhs_1))
-    )
-
-   (
-    ($check_trans (and (= lhs_1 rhs) eqs) (@cl (= lhs_2 rhs)))
-
-    ($f_list_equal = ($make_trans (and (= lhs_1 rhs) eqs) rhs) (= lhs_2 rhs))
     )
   )
 )
@@ -1106,8 +1067,7 @@
 ; program: check_and
 ; args:
 ; - premise Bool       : >
-;   Premise of the "and" rule: a conjunction of terms. 
-;   It could be embedded within a single-term clause 
+;   Premise of the "and" rule: a conjunction of terms, embedded within a single-term clause 
 ;   (built with @cl).
 ; - index Int          : >
 ;   Conjunct index, as provided to the rule. 0 <= index <= number of conjuncts - 1
@@ -1118,9 +1078,13 @@
 ;   "premise", with index "index".
 (program $check_and ((premise Bool) (premise_non_cl Bool) (index Int) (conclusion Bool))
   (Bool Int Bool) Bool
-  ((($check_and premise index conclusion)
+  (
+   (
+    ($check_and premise index conclusion)
+
     ($cl_equal ($to_cl ($f_list_index and ($from_cl premise) index))
-               conclusion))
+               conclusion)
+    )
   )
 )
 
@@ -1209,14 +1173,13 @@
 ;   with @cl.
 (program $check_or ((premise Bool) (conclusion Bool))
   (Bool Bool) Bool
-  ((($check_or (@cl premise) conclusion)
+  (
+   (
+    ($check_or (@cl premise) conclusion)
+
     ($cl_equal ($convert_or_to_cl premise)
                conclusion)
     )
-
-   ; { premise is not built with @cl }
-   (($check_or premise conclusion)
-    ($cl_equal ($convert_or_to_cl premise) conclusion))
   )
 )
 
@@ -1251,7 +1214,7 @@
 ;   "premise".
 (program $check_not_and ((conjunction Bool) (conclusion Bool))
   (Bool Bool) Bool
-  ((($check_not_and (not conjunction) conclusion)
+  ((($check_not_and (@cl (not conjunction)) conclusion)
      ($cl_equal ($de_morgan_not_and conjunction) conclusion)
      )
   )
@@ -1268,7 +1231,7 @@
 ;  Only the "requires" predicate checks if a proper conclusion is given.
 (declare-rule not_and ((premise Bool))
   :premises (premise)
-  :requires ((($check_not_and ($from_cl premise) eo::conclusion) true))
+  :requires ((($check_not_and premise eo::conclusion) true))
   :conclusion-given
 )
 
@@ -1366,12 +1329,11 @@
 (program $check_implies ((phi1 Bool) (phi2 Bool) (conclusion Bool))
   (Bool Bool) Bool
   (
-   (($check_implies (@cl (=> phi1 phi2)) conclusion)
+   (
+    ($check_implies (@cl (=> phi1 phi2)) conclusion)
+
      ($cl_equal (@cl (not phi1) phi2) conclusion)
-   )
-   (($check_implies (=> phi1 phi2) conclusion)
-     ($cl_equal (@cl (not phi1) phi2) conclusion)
-   )
+   )   
   )
 )
 
@@ -1558,12 +1520,18 @@
 (program $check_and_pos ((pos Int) (antecedent Bool) (consequent Bool))
   (Int Bool) Bool
   (
-   (($check_and_pos pos (@cl (not antecedent) consequent))
-    ($cl_equal ($f_list_index and antecedent pos) consequent))
+   (
+    ($check_and_pos pos (@cl (not antecedent) consequent))
+
+    ($cl_equal ($f_list_index and antecedent pos) consequent)
+    )
 
    ; To simplify the use of the checker
-   (($check_and_pos pos (@cl consequent (not antecedent)))
-    ($cl_equal ($f_list_index and antecedent pos) consequent))
+   (
+    ($check_and_pos pos (@cl consequent (not antecedent)))
+
+    ($cl_equal ($f_list_index and antecedent pos) consequent)
+    )
   )
 )
 
@@ -1600,9 +1568,11 @@
 (program $check_and_neg ((left_disjunct Bool) (right_disjunct Bool :list))
   (Bool) Bool
   (
-   (($check_and_neg (@cl left_disjunct right_disjunct))
-    ($cl_equal ($de_morgan_not_and left_disjunct)
-              right_disjunct))
+   (
+    ($check_and_neg (@cl left_disjunct right_disjunct))
+
+    ($cl_equal ($de_morgan_not_and left_disjunct) right_disjunct)
+    )
   )
 )
 
@@ -1632,7 +1602,9 @@
 (program $check_or_pos ((left_disjunct Bool) (right_disjunct Bool :list))
   (Bool) Bool
   (
-   (($check_or_pos (@cl (not left_disjunct) right_disjunct))
+   (
+    ($check_or_pos (@cl (not left_disjunct) right_disjunct))
+
     ($cl_equal ($convert_or_to_cl left_disjunct)
               (@cl right_disjunct))
     )
@@ -1669,11 +1641,17 @@
 (program $check_or_neg ((index Int) (left_disjunct Bool) (right_disjunct Bool))
   (Int Bool) Bool
   (
-   (($check_or_neg index (@cl left_disjunct (not right_disjunct)))
-    ($prop_syntax_eq ($f_list_index or left_disjunct index) right_disjunct))
+   (
+    ($check_or_neg index (@cl left_disjunct (not right_disjunct)))
+    
+    ($prop_syntax_eq ($f_list_index or left_disjunct index) right_disjunct)
+    )
    
-   (($check_or_neg index (@cl (not left_disjunct) right_disjunct))
-    ($prop_syntax_eq right_disjunct ($f_list_index or left_disjunct index)))
+   (
+    ($check_or_neg index (@cl (not left_disjunct) right_disjunct))
+    
+    ($prop_syntax_eq right_disjunct ($f_list_index or left_disjunct index))
+    )
   )
 )
 
@@ -1767,14 +1745,23 @@
 (program $check_implies_pos ((phi_1 Bool) (phi_2 Bool) (phi_3 Bool) (phi_4 Bool))
   (Bool) Bool
   (; TODO: simplify this
-   (($check_implies_pos (@cl (not (=> phi_1 phi_2)) phi_3 phi_4))
-    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4)))
+   (
+    ($check_implies_pos (@cl (not (=> phi_1 phi_2)) phi_3 phi_4))
 
-   (($check_implies_pos (@cl phi_3 (not (=> phi_1 phi_2)) phi_4))
-    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4)))
+    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4))
+    )
 
-   (($check_implies_pos (@cl phi_3 phi_4 (not (=> phi_1 phi_2))))
-    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4)))
+   (
+    ($check_implies_pos (@cl phi_3 (not (=> phi_1 phi_2)) phi_4))
+
+    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4))
+    )
+
+   (
+    ($check_implies_pos (@cl phi_3 phi_4 (not (=> phi_1 phi_2))))
+    
+    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4))
+    )
   )
 )
 
@@ -1805,14 +1792,23 @@
 (program $check_implies_neg1 ((phi_1 Bool) (phi_2 Bool))
   (Bool) Bool
   (
-   (($check_implies_neg1 (@cl (=> phi_1 phi_2) phi_1))
-    true)
+   (
+    ($check_implies_neg1 (@cl (=> phi_1 phi_2) phi_1))
+    
+    true
+    )
 
-   (($check_implies_neg1 (@cl phi_1 (=> phi_1 phi_2)))
-    true)
+   (
+    ($check_implies_neg1 (@cl phi_1 (=> phi_1 phi_2)))
 
-   (($check_implies_neg1 phi_1)
-    false)
+    true
+    )
+
+   (
+    ($check_implies_neg1 phi_1)
+
+    false
+    )
   )
 )
 
@@ -1922,17 +1918,29 @@
 (program $check_equiv_pos2 ((phi_1 Bool) (phi_2 Bool) (phi_3 Bool) (phi_4 Bool))
   (Bool) Bool
   (; TODO: simplify this
-   (($check_equiv_pos2 (@cl (not (= phi_1 phi_2)) phi_3 phi_4))
-    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4)))
-   
-   (($check_equiv_pos2 (@cl phi_3 (not (= phi_1 phi_2)) phi_4))
-    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4)))
-   
-   (($check_equiv_pos2 (@cl phi_3 phi_4 (not (= phi_1 phi_2))))
-    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4)))
+   (
+    ($check_equiv_pos2 (@cl (not (= phi_1 phi_2)) phi_3 phi_4))
 
-   (($check_equiv_pos2 phi_1)
-    false)
+    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4))
+    )
+   
+   (
+    ($check_equiv_pos2 (@cl phi_3 (not (= phi_1 phi_2)) phi_4))
+
+    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4))
+    )
+   
+   (
+    ($check_equiv_pos2 (@cl phi_3 phi_4 (not (= phi_1 phi_2))))
+
+    ($cl_equal (@cl (not phi_1) phi_2) (@cl phi_3 phi_4))
+    )
+
+   (
+    ($check_equiv_pos2 phi_1)
+
+    false
+    )
   )
 )
 
@@ -2210,11 +2218,13 @@
 (program $check_equiv_simplify ((phi_1 Bool) (phi_2 Bool) (psy Bool))
   (Bool) Bool
   (
-   (($check_equiv_simplify (@cl (= (= phi_1 phi_2) psy)))
-                            ; TODO: use proper comparison for props
-                            ($cl_equal (@cl ($rewrite_equivalence (= phi_1 phi_2)))
-                                      (@cl psy)))
-  )
+   (
+    ($check_equiv_simplify (@cl (= (= phi_1 phi_2) psy)))
+    
+                                        ; TODO: use proper comparison for props
+    ($cl_equal (@cl ($rewrite_equivalence (= phi_1 phi_2))) (@cl psy))
+    )
+   )
 )
 
 ; rule: equiv_simplify
@@ -2475,21 +2485,28 @@
    )
 )
 
-; This has to traverse the lets and the premises. Also has to check the
-; context extension.
 ; program: check_let_elim
 ; args:
-; - ctx Bool:
-; - Cs Bool:
-; - conclusion Bool:
-; return:
+; - context Bool: Context of the subproof being closed.
+; - premises Bool: And-list containing premises passed to rule let_elim.
+; - conclusion Bool: Conclusion given to rule let_elim.
+; return: >
+;    A boolean indicating if the given conclusion has the form
+;    (let 𝑥1 = 𝑡1, … , 𝑥𝑛= 𝑡𝑛 in 𝑢) ≈ 𝑢′
+;    And the premises are of the form:
+;    𝑖1. Γ ⊳ 𝑡1 ≈ 𝑠1 (… )
+;     ...
+;   𝑖𝑛. Γ ⊳ 𝑡𝑛 ≈ 𝑠𝑛 (… )
+;   𝑗. Γ, 𝑥1 ↦𝑠1, … , 𝑥𝑛 ↦ 𝑠𝑛 ⊳ 𝑢 ≈ 𝑢′ (… )
+;   Note that the context given must correspond to the one of the immediate
+;   premise j, that is, Γ, 𝑥1 ↦𝑠1, … , 𝑥𝑛 ↦ 𝑠𝑛.
 (program $check_let_elim ((context Bool) (premises Bool) 
                          (let_type Type) (let_def let_type)
                          (var_defs @VarList) 
                          (A Type) (lhs A) (rhs A)
                          (B Type)
                          (var_values B))
-  (Bool Bool let_type) Bool
+  (Bool Bool Bool) Bool
   (
    (
     ($check_let_elim context premises
@@ -2497,7 +2514,7 @@
 
     (eo::and 
      ; There should be a conclusion of the form (@cl (= lhs rhs))
-     ; TODO: this conclusion must be just of the previous step
+     ; TODO: this must be the just the conclusion of the previous step
      ($f_list_contains_elem and (@cl (= ($let_get_body let_def) rhs)) premises)
      ($verify_let_premises context premises 
                           ($let_get_vars_substitutes ($let_get_vars let_def)
@@ -2510,11 +2527,12 @@
 ; rule: let_elim
 ; assumption:
 ; - ctx: Context from the actual subproof.
-; premise-list:
-; - Cs: Surrounding context 
-; conclusion: >
-;   
-; note: >
+; premise-list: And-list of the premises passed to the rule.
+; requires: >
+;    For the given conclusion to be a proper elimination of a let, under the provided
+;    premises and context, as specified by predicate $check_let_elim.
+; conclusion-given >
+;    Only the "requires" predicate checks if a proper conclusion is given.
 (declare-rule let_elim ((ctx Bool) (premises Bool))
   :assumption ctx
   :premise-list premises and
@@ -2535,25 +2553,33 @@
 (program $build_distinct_list ((A Type) (lhs A) (rhs A) (tl Bool :list))
   (Bool) Bool
   (
-   (($build_distinct_list (and (distinct lhs rhs) tl))
+   (
+    ($build_distinct_list (and (distinct lhs rhs) tl))
 
     ($f_list_cons and 
                  (not (= lhs rhs)) 
-                 ($build_distinct_list tl)))
+                 ($build_distinct_list tl))
+    )
 
    ; Only one proposition
-   (($build_distinct_list (distinct lhs rhs)) 
+   (
+    ($build_distinct_list (distinct lhs rhs)) 
 
-    (not (= lhs rhs)))
+    (not (= lhs rhs))
+    )
 
    ; Only one proposition
-   (($build_distinct_list (distinct lhs)) 
+   (
+    ($build_distinct_list (distinct lhs)) 
 
-    true)
+    true
+    )
    
-   (($build_distinct_list true) 
+   (
+    ($build_distinct_list true) 
 
-    true)
+    true
+    )
   )
 )
 
@@ -2565,37 +2591,49 @@
 ;   An inequality of the form (not (= lhs rhs)), for some terms lhs and rhs of
 ;   type A.
 ; - conjunctions Bool: A conjunctions of inequalities of the form (not (= lhs' rhs'))
-; return:
-;   A boolean indicating if ineq appears in "conjunctions".
+; return: >
+;   A boolean indicating if ineq appears in "conjunctions", modulo symmetry of the
+;   equality within ineq.
 (program $conjunction_contains_ineq ((A Type) (lhs A) (rhs A) (hd Bool) (tl Bool :list))
   (Bool Bool) Bool
   (
-   (($conjunction_contains_ineq (not (= lhs rhs)) (and (not (= lhs rhs)) tl))
+   (
+    ($conjunction_contains_ineq (not (= lhs rhs)) (and (not (= lhs rhs)) tl))
 
-    true)
+    true
+    )
 
-   (($conjunction_contains_ineq (not (= lhs rhs)) (and (not (= rhs lhs)) tl))
+   (
+    ($conjunction_contains_ineq (not (= lhs rhs)) (and (not (= rhs lhs)) tl))
 
-    true)
+    true
+    )
 
    ; { hd =/= not (= rhs lhs))}
-   (($conjunction_contains_ineq (not (= lhs rhs)) (and hd tl))
+   (
+    ($conjunction_contains_ineq (not (= lhs rhs)) (and hd tl))
 
-    ($conjunction_contains_ineq (not (= lhs rhs)) tl))
+    ($conjunction_contains_ineq (not (= lhs rhs)) tl)
+    )
 
-   
-   (($conjunction_contains_ineq (not (= lhs rhs)) (not (= lhs rhs)))
+   (
+    ($conjunction_contains_ineq (not (= lhs rhs)) (not (= lhs rhs)))
 
-    true)
+    true
+    )
 
-   (($conjunction_contains_ineq (not (= lhs rhs)) (not (= rhs lhs)))
+   (
+    ($conjunction_contains_ineq (not (= lhs rhs)) (not (= rhs lhs)))
 
-    true)
+    true
+    )
 
    ; { hd =/= (not (= lhs rhs))}
-   (($conjunction_contains_ineq (not (= lhs rhs)) hd)
+   (
+    ($conjunction_contains_ineq (not (= lhs rhs)) hd)
 
-    false)
+    false
+    )
   )
 )
 
@@ -2603,27 +2641,36 @@
 ; args:
 ; - list_1 A: An and-list, of inequalities of the form (not (= lhs rhs))
 ; - list_2 A: An and-list, of inequalities of the form (not (= lhs rhs)).
-; return:
-; A boolean indicating if the elements from list_1 also appear in list_2.
+; return: >
+;    A boolean indicating if the elements from list_1 also appear in list_2, 
+;    according to comparison predicate $conjunction_contains_ineq.
 (program $conjunction_contains_conjunction ((hd Bool) (tl Bool :list)
                                            (f_list_2 Bool))
   (Bool Bool) Bool
   (
-   (($conjunction_contains_conjunction (and hd tl) f_list_2)
+   (
+    ($conjunction_contains_conjunction (and hd tl) f_list_2)
+
     ; TODO: I need some way to build boolean values
     ; combining other boolean values, but I would like
     ; to avoid built-in operators.
     (eo::and ($conjunction_contains_ineq hd f_list_2)
-             ($conjunction_contains_conjunction tl f_list_2)))
+             ($conjunction_contains_conjunction tl f_list_2))
+    )
 
- 
    ; { f_list_1 is not an and-list}
-   (($conjunction_contains_conjunction true f_list_2)
-    true)
-   
+   (
+    ($conjunction_contains_conjunction true f_list_2)
+
+    true
+    )
+
    ; { hd must be an inequaity }
-   (($conjunction_contains_conjunction hd f_list_2)
-    ($conjunction_contains_ineq hd f_list_2))
+   (
+    ($conjunction_contains_conjunction hd f_list_2)
+
+    ($conjunction_contains_ineq hd f_list_2)
+    )
   )
 )
 
@@ -2637,9 +2684,12 @@
 (program $conjunctions_equal ((list_1 Bool) (list_2 Bool))
   (Bool Bool) Bool
   (
-   (($conjunctions_equal list_1 list_2)
+   (
+    ($conjunctions_equal list_1 list_2)
+    
     (eo::and ($conjunction_contains_conjunction list_1 list_2)
-             ($conjunction_contains_conjunction list_2 list_1)))
+             ($conjunction_contains_conjunction list_2 list_1))
+    )
   )
 )
 
@@ -2652,12 +2702,18 @@
 (program $check_distinct_elim ((A Type) (hd A) (inequalities Bool) (conjunctions Bool))
   (Bool) Bool
   (; TODO: assuming that inequalities come first
-   (($check_distinct_elim (@cl (= inequalities conjunctions)))
-    ($conjunctions_equal ($build_distinct_list inequalities)
-                        conjunctions))
+   (
+    ($check_distinct_elim (@cl (= inequalities conjunctions)))
+    
+    ($conjunctions_equal ($build_distinct_list inequalities) conjunctions)
+    )
 
    ; Only one proposition
-   (($check_distinct_elim (@cl (= (distinct hd) true))) true)
+   (
+    ($check_distinct_elim (@cl (= (distinct hd) true))) 
+    
+    true
+    )
   )
 )
 
@@ -2687,7 +2743,11 @@
 (program $check_la_rw_eq ((t Real) (u Real))
   (Bool) Bool
   (
-   (($check_la_rw_eq (@cl (= (= t u) (and (<= t u) (<= u t))))) true)
+   (
+    ($check_la_rw_eq (@cl (= (= t u) (and (<= t u) (<= u t))))) 
+    
+    true
+    )
   )
 )
 
@@ -2721,9 +2781,8 @@
 (program $check_nary_elim ((A Type) (hd A) (tl A :list))
   (Bool) Bool
   (; TODO: check that op is not /\ nor \/
-   ; TODO: do we have reflection mechanisms, useful to inspect properties
-   ; of each operator, and define this program in a generic way?
-   (($check_nary_elim (@cl (= (=> hd tl) (=> hd tl))))
+   (
+    ($check_nary_elim (@cl (= (=> hd tl) (=> hd tl))))
     ; right-assoc operator
     ; We leverage the desugaring process, that turns both lists
     ; into the folded application of the operator, already
@@ -2798,12 +2857,6 @@
   (Bool Bool) Bool
   (
    (
-    ($check_symm (= phi psy) (@cl (= psy phi))) 
-
-    true
-    )
-
-   (
     ($check_symm (@cl (= phi psy)) (@cl (= psy phi))) 
 
     true
@@ -2844,7 +2897,7 @@
     ($check_reordering (@cl hd_premise tl_premise) (@cl hd_conclusion tl_conclusion))
 
     ($check_reordering tl_premise 
-                      ($f_list_remove_elem @cl (@cl hd_conclusion tl_conclusion) hd_premise false))
+                       ($f_list_remove_elem @cl (@cl hd_conclusion tl_conclusion) hd_premise false))
     )
 
    (

--- a/signature/lists.eo
+++ b/signature/lists.eo
@@ -298,180 +298,65 @@
           )
          )
 
-; program: $is_f_list
+; program: $is_theory_f_list
 ; args:
-; - list T : >
-;    A term representing the application of some operator over a sequence of operands.
-; return: A boolean indicating if the given parameter is an actual list or not.
-(program $is_f_list ((U Type) (T Type) (f (-> U T T)) (hd U) (tail T :list))
-         :signature (T) Bool
+; - f (-> T U): A function constant.
+; return: >
+;    A boolean indicating if the given parameter is a list operator or not, depending
+;    on whether the applied operator is actually defined in our theory, as
+;    left/right assoc-nil. In any other case, it returns false.
+(program $is_theory_f_list ((U Type) (T Type) (f (-> T U)))
+         :signature ((-> T U)) Bool
          (
           (
-           ($is_f_list (@cl hd tail))
+           ($is_theory_f_list @cl)
 
            true
            )
 
           (
-           ($is_f_list (or hd tail))
+           ($is_theory_f_list or)
 
            true
            )
 
           (
-           ($is_f_list (and hd tail))
+           ($is_theory_f_list and)
 
            true
            )
 
           (
-           ($is_f_list (+ hd tail))
+           ($is_theory_f_list +)
 
            true
            )
 
           (
-           ($is_f_list (* hd tail))
+           ($is_theory_f_list *)
 
            true
            )
 
           (
-           ($is_f_list (@varlist hd tail))
+           ($is_theory_f_list @varlist)
 
            true
            )
 
           (
-           ($is_f_list (@substitution hd tail))
+           ($is_theory_f_list @substitution)
 
            true
            )
 
           (
-           ($is_f_list tail)
+           ($is_theory_f_list f)
 
            false
            )
           )
          )
-; program: $f_list_nil_element
-; args:
-; - f (-> U T T): A left/right-assoc-nil operator.
-; return: The nil terminator of "f".
-(program $f_list_nil_element ((U Type) (T Type) (f (-> U T T)))
-         :signature ((-> U T T)) T
-         (
-          (
-           ($f_list_nil_element @cl)
-
-           false
-           )
-
-          (
-           ($f_list_nil_element or)
-
-           false
-           )
-
-          (
-           ($f_list_nil_element and)
-
-           true
-           )
-
-          (
-           ($f_list_nil_element +)
-
-           0
-           )
-
-          (
-           ($f_list_nil_element *)
-
-           1
-           )
-
-          (
-           ($f_list_nil_element @varlist)
-
-           @varlist.nil
-           )
-
-          (
-           ($f_list_nil_element @varlist)
-
-           @substitution.nil
-           )
-          )
-         )
-
-; program: $f_list_remove_nil_terminator_left_assoc
-; args:
-; - f (-> U T T): A left-assoc-nil operator.
-; - list T: A nil-terminated f-list.
-; - nil T: The nil terminated of the f-lists.
-; return: >
-;    A list that is equal to "list", without its nil terminator.
-(program $f_list_remove_nil_terminator_left_assoc ((U Type) (T Type) (f (-> U T T)) (hd U) (tail T :list) (nil T))
-         :signature ((-> U T T) T U) T
-         (
-          (;TODO: ill-typed
-           ($f_list_remove_nil_terminator_left_assoc f (f hd nil) nil)
-
-           hd
-           )
-
-          (
-           ($f_list_remove_nil_terminator_left_assoc f (f hd tail) nil)
-           
-           ($f_list_cons f ($f_list_remove_nil_terminator_left_assoc f hd nil) tail)
-           )
-          )
-         )
-
-; program: $f_list_remove_nil_terminator_right_assoc
-; args:
-; - f (-> U T T): A right-assoc-nil operator.
-; - list T: A nil-terminated f-list.
-; - nil T: The nil terminated of the f-lists.
-; return: >
-;    A list that is equal to "list", without its nil terminator.
-(program $f_list_remove_nil_terminator_right_assoc ((U Type) (T Type) (f (-> U T T)) (hd U) (tail T :list) (nil T))
-         :signature ((-> U T T) T U) T
-         (
-          (;TODO: ill-typed
-           ($f_list_remove_nil_terminator_right_assoc f (f hd nil) nil)
-
-           hd
-           )
-
-          (; { tail != nil }
-           ($f_list_remove_nil_terminator_right_assoc f (f hd tail) nil)
-           
-           ($f_list_cons f hd ($f_list_remove_nil_terminator_right_assoc f tail nil))
-           )
-          )
-         )
-
-; program: $f_list_remove_nil_terminator
-; args:
-; - list T: nil-terminated f-list .
-; return: >
-;    An f-list that is equal to "list" but without its nil-terminator.
-(program $f_list_remove_nil_terminator ((U Type) (T Type) (f (-> U T T)) (hd U) (tail T :list))
-         :signature (T) T
-         (
-          (
-           ($f_list_remove_nil_terminator (f hd tail))
-
-           (eo::ite ($f_list_operator_is_right_assoc f)
-                    ($f_list_remove_nil_terminator_right_assoc f (f hd tail) ($f_list_nil_element f))
-                    ;; { f is left-assoc }
-                    ($f_list_remove_nil_terminator_left_assoc f (f hd tail) ($f_list_nil_element f)))
-           )
-          )
-)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; lists (built with non-variadic operators)

--- a/signature/lists.eo
+++ b/signature/lists.eo
@@ -1,21 +1,25 @@
 (include "./theory.eo")
 
-; Library of auxiliary programs, useful to manipulate f-lists:
-; associative operators with nil-terminators
+; Library of auxiliary programs, useful to manipulate f-lists (associative 
+; operators with nil-terminators) and related structures
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; f-lists
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; define: f_list_index
 ; args:
-; - f (-> A A A): >
+; - f (-> A B B): >
 ;   Right/left assoc. operator used to construct the given f-list
 ;   (see definition of f-list, for a given operator f, in ethos
 ;   manual: https://github.com/cvc5/ethos/blob/main/user_manual.md#list-computations)
-; - list (A): An f-list: a term of the form (f t1 ... tn)
+; - list (B): An f-list: a term of the form (f t1 ... tn)
 ; - index Int: >
 ;   An integer, from 0 to the number of parameters - 1 in (f t1 ... tn) 
 ;   (i.e., "list)
 ; return: The parameter number "index", from (f t1 ... tn).
-(program $f_list_index ((A Type) (f (-> A A A)) (hd A) (tail A :list) (index Int))
-  ((-> A A A) A Int) A
+(program $f_list_index ((A Type) (B Type) (f (-> A B B)) (hd A) (tail B :list) (index Int))
+  ((-> A B B) B Int) A
   (
    (
     ($f_list_index f (f hd tail) 0) 
@@ -38,14 +42,14 @@
 
 ; program: f_list_contains_elem
 ; args:
-; - f (-> A A A): Operator used to build the f-list.
+; - f (-> A B B): Operator used to build the f-list.
 ; - elem A: Some element of type A, for which we want to test membership.
-; - list A: An f-list.
+; - list B: An f-list.
 ; return:
 ; A boolean indicating if "elem" appears in f-list "list".
-(program $f_list_contains_elem ((A Type) (f (-> A A A))
-                               (elem A) (hd A) (tl A :list))
-  ((-> A A A) A A) Bool
+(program $f_list_contains_elem ((A Type) (B Type) (f (-> A B B))
+                               (elem A) (hd A) (tl B :list))
+  ((-> A B B) A B) Bool
   (
    (($f_list_contains_elem f elem (f elem tl))
 
@@ -70,15 +74,15 @@
 
 ; program: f_list_contains_elem
 ; args:
-; - f (-> A A A): Operator used to build the f-list.
-; - list_1 A: An f-list.
-; - list_2 A: An f-list.
+; - f (-> A B B): Operator used to build the f-list.
+; - list_1 B: An f-list.
+; - list_2 B: An f-list.
 ; return:
 ; A boolean indicating if the elements from list_1 also appear in list_2.
-(program $f_list_contains_f_list ((A Type) (f (-> A A A))
-                                 (hd A) (tl A :list)
-                                 (f_list_2 A))
-  ((-> A A A) A A) Bool
+(program $f_list_contains_f_list ((A Type) (B Type) (f (-> A B B))
+                                 (hd A) (tl B :list)
+                                 (f_list_2 B))
+  ((-> A B B) B B) Bool
   (
    (($f_list_contains_f_list f (f hd tl) f_list_2)
     ;; TODO: I need some way to build boolean values
@@ -96,15 +100,15 @@
 
 ; program: f_list_equal
 ; args:
-; - f (-> A A A): Operator used to build the f-list.
-; - list_1 A: An f-list.
-; - list_2 A: An f-list.
+; - f (-> A B B): Operator used to build the f-list.
+; - list_1 B: An f-list.
+; - list_2 B: An f-list.
 ; return: >
 ; A boolean indicating if the operands from list_1 and list_2 are the 
 ; same, regardless of the order and possible repetitions.
-(program $f_list_equal ((A Type) (f (-> A A A))
-                       (f_list_1 A) (f_list_2 A))
-  ((-> A A A) A A) Bool
+(program $f_list_equal ((A Type) (B Type) (f (-> A B B))
+                       (f_list_1 B) (f_list_2 B))
+  ((-> A B B) B B) Bool
   (
    (($f_list_equal f f_list_1 f_list_2)
     (eo::and ($f_list_contains_f_list f f_list_1 f_list_2)
@@ -114,28 +118,29 @@
 
 ; program: f_list_concat
 ; args:
-; - f (-> A A A): Operator used to build the f-list.
+; - f (-> A B B): Operator used to build the f-list.
 ; - elem A: An element of type A.
-; - flist A: An f-list.
+; - flist B: An f-list.
 ; return: >
 ;    Returns an f-list, with first operand "elem", followed by operands of flist_2.
-(define $f_list_cons ((A Type :implicit) (f (-> A A A)) (elem A)
-                     (tail A :list))
+(define $f_list_cons ((A Type :implicit) (B Type :implicit) (f (-> A B B)) (elem A)
+                     (tail B :list))
     (f elem tail)
 )
 
 ; program: f_list_remove_elem
 ; args:
+; - f (-> A B B): Operator used to build the f-list.
 ; - list B: An f-list, where f is a variadic operator with some "nil" element.
-; - f_nil A: The "nil" element of variadic operator f.
+; - f_nil B: The "nil" element of variadic operator f.
 ; - elem A: An element from "list" that we want to remove.
 ; return: >
 ;   Removes the first occurrence of "elem" in the given f-list. Returns
 ;   the obtained f-list.
 (program $f_list_remove_elem ((A Type) (B Type)
-                             (f (-> A A B)) (f_nil A) (hd A) (tl A :list)
+                             (f (-> A B B)) (f_nil B) (hd A) (tl B :list)
                              (elem A))
-  ((-> A A B) B A A) B
+  ((-> A B B) B A B) B
 
   (
    (
@@ -166,18 +171,22 @@
   )
 
 ; TODO: implement this as a higher-order program, once it becomes feasible
-; program: $f_list_filter
+; program: f_list_remove_elem
 ; args:
-; - hd Bool:
-; - cl_tl Bool:
-; - varlist_tl @VarList:
-; return:
-(program $f_list_filter ((A Type) (f (-> A A A)) (nil_elem A)
-                         (hd A) (f_tl A :list) (varlist_tl @VarList :list))
-         ((-> A A A) A A @VarList) A
+; - f (-> A B B): Operator used to build the f-list.
+; - f_nil B: The "nil" element of variadic operator f.
+; - list B: An f-list, where f is a variadic operator with some "nil" element.
+; - flags @VarList: List of flags indicating which element must be removed.
+; return: >
+;   Removes element in index i from "list", if the flag in position i from 
+;   "flags" is true.
+(program $f_list_filter ((A Type) (B Type) (f (-> A B B)) (nil_elem B)
+                         (hd A) (f_tl B :list) (varlist_tl @VarList :list))
+         ((-> A B B) B B @VarList) B
          (
           (
            ($f_list_filter f nil_elem (f hd f_tl) (@varlist true varlist_tl))
+
            ($f_list_filter f nil_elem f_tl varlist_tl)
            )
 
@@ -207,13 +216,14 @@
 
 ; program: $f_list_last_element
 ; args:
-; - f (-> A A A): Operator used to build the f-list.
-; - f-list A: A non-empty f-list.
+; - f (-> A B B): Operator used to build the f-list.
+; - nil B: Nil element of operator f.
+; - f-list B: A non-empty f-list.
 ; precondition: f-list is not empty.
 ; return: Last element of f-list.
-(program $f_list_last_element ((A Type) (f (-> A A A))
-                               (hd A) (f_tl A :list))
-         ((-> A A A) A) A
+(program $f_list_last_element ((A Type) (B Type) (f (-> A B B))
+                               (hd A) (nil_elem A) (f_tl A :list))
+         ((-> A B B) B B) A
          (
           (
            ($f_list_last_element f nil_elem (f hd nil_elem))
@@ -226,11 +236,79 @@
 
            ($f_list_last_element f nil_elem f_tl)
            )
+          )
+         )
 
-          (; { hd is not an f-list }
-           ($f_list_last_element f nil_elem hd)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; lists (built with non-variadic operators)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; program: $list_last_element
+; args:
+; - f (-> A B B): An n-ary operator used to build the list.
+; - list B: A non-empty list.
+; precondition: list is not empty.
+; return: Last element of list.
+(program $list_last_element ((A Type) (B Type) (f (-> A B B))
+                               (hd A) (f_tl B :list))
+         ((-> A B B) B) A
+         (
+          (
+           ($list_last_element f (f hd f_tl))
+
+           ($list_last_element f f_tl)
+           )
+
+          (
+           ($list_last_element f (f hd))
+
+           hd
+           )
+
+          (; { hd is not a list }
+           ($list_last_element f hd)
 
            hd
            )
           )
          )
+
+; program: list_remove_elem
+; args:
+; - f (-> A B B): an n-ary operator
+; - list B: An list, built with f.
+; - elem A: An element from "list" that we want to remove.
+; return: >
+;   Removes the first occurrence of "elem" in the given list. Returns
+;   the obtained list.
+(program $list_remove_elem ((A Type) (B Type)
+                             (f (-> A B B)) (hd A) (tl B :list)
+                             (elem A))
+  ((-> A B B) B A) B
+
+  (
+   (
+    ($list_remove_elem f (f hd elem) elem)
+    
+    (f hd)
+    )
+
+   (
+    ($list_remove_elem f (f elem tl) elem)
+    
+    tl
+    )
+
+   (; { hd =/= elem }
+    ($list_remove_elem f (f hd tl) elem)
+    
+    ($f_list_cons f hd ($list_remove_elem f tl elem))
+    )
+
+   (; TODO: this should be an error
+    ($list_remove_elem f (f elem) elem)
+    
+    f
+    )
+   )
+  )

--- a/signature/lists.eo
+++ b/signature/lists.eo
@@ -171,7 +171,7 @@
   )
 
 ; TODO: implement this as a higher-order program, once it becomes feasible
-; program: f_list_remove_elem
+; program: f_list_filter
 ; args:
 ; - f (-> A B B): Operator used to build the f-list.
 ; - f_nil B: The "nil" element of variadic operator f.
@@ -238,6 +238,240 @@
            )
           )
          )
+
+;-------------
+; Reflection
+;-------------
+
+; program: $f_list_operator_is_right_assoc
+; args:
+; - f (-> A A B): Operator upon which we want to reflect.
+; return: A boolean indicating if the operator is declared as right assoc.
+(program $f_list_operator_is_right_assoc ((A Type) (B Type) (f (-> A B B)))
+         :signature ((-> A B B)) Bool
+         (
+          (
+           ($f_list_operator_is_right_assoc @cl)
+
+           true
+           )
+
+          (
+           ($f_list_operator_is_right_assoc or)
+
+           true
+           )
+
+          (
+           ($f_list_operator_is_right_assoc and)
+
+           true
+           )
+
+          (
+           ($f_list_operator_is_right_assoc +)
+
+           true
+           )
+
+          (
+           ($f_list_operator_is_right_assoc *)
+
+           true
+           )
+
+          (
+           ($f_list_operator_is_right_assoc @varlist)
+           true
+           )
+
+          (; TODO : not sure about declaring @substitution as right_assoc
+           ($f_list_operator_is_right_assoc @substitution)
+           true
+           )
+
+          (
+           ($f_list_operator_is_right_assoc f)
+
+           false
+           )
+          )
+         )
+
+; program: $is_f_list
+; args:
+; - list T : >
+;    A term representing the application of some operator over a sequence of operands.
+; return: A boolean indicating if the given parameter is an actual list or not.
+(program $is_f_list ((U Type) (T Type) (f (-> U T T)) (hd U) (tail T :list))
+         :signature (T) Bool
+         (
+          (
+           ($is_f_list (@cl hd tail))
+
+           true
+           )
+
+          (
+           ($is_f_list (or hd tail))
+
+           true
+           )
+
+          (
+           ($is_f_list (and hd tail))
+
+           true
+           )
+
+          (
+           ($is_f_list (+ hd tail))
+
+           true
+           )
+
+          (
+           ($is_f_list (* hd tail))
+
+           true
+           )
+
+          (
+           ($is_f_list (@varlist hd tail))
+
+           true
+           )
+
+          (
+           ($is_f_list (@substitution hd tail))
+
+           true
+           )
+
+          (
+           ($is_f_list tail)
+
+           false
+           )
+          )
+         )
+; program: $f_list_nil_element
+; args:
+; - f (-> U T T): A left/right-assoc-nil operator.
+; return: The nil terminator of "f".
+(program $f_list_nil_element ((U Type) (T Type) (f (-> U T T)))
+         :signature ((-> U T T)) T
+         (
+          (
+           ($f_list_nil_element @cl)
+
+           false
+           )
+
+          (
+           ($f_list_nil_element or)
+
+           false
+           )
+
+          (
+           ($f_list_nil_element and)
+
+           true
+           )
+
+          (
+           ($f_list_nil_element +)
+
+           0
+           )
+
+          (
+           ($f_list_nil_element *)
+
+           1
+           )
+
+          (
+           ($f_list_nil_element @varlist)
+
+           @varlist.nil
+           )
+
+          (
+           ($f_list_nil_element @varlist)
+
+           @substitution.nil
+           )
+          )
+         )
+
+; program: $f_list_remove_nil_terminator_left_assoc
+; args:
+; - f (-> U T T): A left-assoc-nil operator.
+; - list T: A nil-terminated f-list.
+; - nil T: The nil terminated of the f-lists.
+; return: >
+;    A list that is equal to "list", without its nil terminator.
+(program $f_list_remove_nil_terminator_left_assoc ((U Type) (T Type) (f (-> U T T)) (hd U) (tail T :list) (nil T))
+         :signature ((-> U T T) T U) T
+         (
+          (;TODO: ill-typed
+           ($f_list_remove_nil_terminator_left_assoc f (f hd nil) nil)
+
+           hd
+           )
+
+          (
+           ($f_list_remove_nil_terminator_left_assoc f (f hd tail) nil)
+           
+           ($f_list_cons f ($f_list_remove_nil_terminator_left_assoc f hd nil) tail)
+           )
+          )
+         )
+
+; program: $f_list_remove_nil_terminator_right_assoc
+; args:
+; - f (-> U T T): A right-assoc-nil operator.
+; - list T: A nil-terminated f-list.
+; - nil T: The nil terminated of the f-lists.
+; return: >
+;    A list that is equal to "list", without its nil terminator.
+(program $f_list_remove_nil_terminator_right_assoc ((U Type) (T Type) (f (-> U T T)) (hd U) (tail T :list) (nil T))
+         :signature ((-> U T T) T U) T
+         (
+          (;TODO: ill-typed
+           ($f_list_remove_nil_terminator_right_assoc f (f hd nil) nil)
+
+           hd
+           )
+
+          (; { tail != nil }
+           ($f_list_remove_nil_terminator_right_assoc f (f hd tail) nil)
+           
+           ($f_list_cons f hd ($f_list_remove_nil_terminator_right_assoc f tail nil))
+           )
+          )
+         )
+
+; program: $f_list_remove_nil_terminator
+; args:
+; - list T: nil-terminated f-list .
+; return: >
+;    An f-list that is equal to "list" but without its nil-terminator.
+(program $f_list_remove_nil_terminator ((U Type) (T Type) (f (-> U T T)) (hd U) (tail T :list))
+         :signature (T) T
+         (
+          (
+           ($f_list_remove_nil_terminator (f hd tail))
+
+           (eo::ite ($f_list_operator_is_right_assoc f)
+                    ($f_list_remove_nil_terminator_right_assoc f (f hd tail) ($f_list_nil_element f))
+                    ;; { f is left-assoc }
+                    ($f_list_remove_nil_terminator_left_assoc f (f hd tail) ($f_list_nil_element f)))
+           )
+          )
+)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; lists (built with non-variadic operators)

--- a/signature/lists.eo
+++ b/signature/lists.eo
@@ -1,0 +1,236 @@
+(include "./theory.eo")
+
+; Library of auxiliary programs, useful to manipulate f-lists:
+; associative operators with nil-terminators
+
+; define: f_list_index
+; args:
+; - f (-> A A A): >
+;   Right/left assoc. operator used to construct the given f-list
+;   (see definition of f-list, for a given operator f, in ethos
+;   manual: https://github.com/cvc5/ethos/blob/main/user_manual.md#list-computations)
+; - list (A): An f-list: a term of the form (f t1 ... tn)
+; - index Int: >
+;   An integer, from 0 to the number of parameters - 1 in (f t1 ... tn) 
+;   (i.e., "list)
+; return: The parameter number "index", from (f t1 ... tn).
+(program $f_list_index ((A Type) (f (-> A A A)) (hd A) (tail A :list) (index Int))
+  ((-> A A A) A Int) A
+  (
+   (
+    ($f_list_index f (f hd tail) 0) 
+
+    hd
+    )
+
+   (; { hd is not an f-list }
+    ($f_list_index f hd 0) 
+
+    hd
+    )
+
+   ;; { index > 0 }
+   (($f_list_index f (f hd tail) index)
+    ;; TODO: using eo::add
+    ($f_list_index f tail (eo::add index -1)))
+  )
+)
+
+; program: f_list_contains_elem
+; args:
+; - f (-> A A A): Operator used to build the f-list.
+; - elem A: Some element of type A, for which we want to test membership.
+; - list A: An f-list.
+; return:
+; A boolean indicating if "elem" appears in f-list "list".
+(program $f_list_contains_elem ((A Type) (f (-> A A A))
+                               (elem A) (hd A) (tl A :list))
+  ((-> A A A) A A) Bool
+  (
+   (($f_list_contains_elem f elem (f elem tl))
+
+    true)
+
+   ; { hd =/= elem}
+   (($f_list_contains_elem f elem (f hd tl))
+
+    ($f_list_contains_elem f elem tl))
+
+   ; { elem is not an f-list}
+   (($f_list_contains_elem f elem elem)
+
+    true)
+   
+   ; { hd =/= elem}
+   (($f_list_contains_elem f elem hd)
+
+    false)
+  )
+)
+
+; program: f_list_contains_elem
+; args:
+; - f (-> A A A): Operator used to build the f-list.
+; - list_1 A: An f-list.
+; - list_2 A: An f-list.
+; return:
+; A boolean indicating if the elements from list_1 also appear in list_2.
+(program $f_list_contains_f_list ((A Type) (f (-> A A A))
+                                 (hd A) (tl A :list)
+                                 (f_list_2 A))
+  ((-> A A A) A A) Bool
+  (
+   (($f_list_contains_f_list f (f hd tl) f_list_2)
+    ;; TODO: I need some way to build boolean values
+    ;; combining other boolean values, but I would like
+    ;; to avoid built-in operators.
+    (eo::and ($f_list_contains_elem f hd f_list_2)
+             ($f_list_contains_f_list f tl f_list_2)))
+
+ 
+   ;; { f_list_1 is not a term built with f }
+   (($f_list_contains_f_list f hd f_list_2)
+    ($f_list_contains_elem f hd f_list_2))
+  )
+)
+
+; program: f_list_equal
+; args:
+; - f (-> A A A): Operator used to build the f-list.
+; - list_1 A: An f-list.
+; - list_2 A: An f-list.
+; return: >
+; A boolean indicating if the operands from list_1 and list_2 are the 
+; same, regardless of the order and possible repetitions.
+(program $f_list_equal ((A Type) (f (-> A A A))
+                       (f_list_1 A) (f_list_2 A))
+  ((-> A A A) A A) Bool
+  (
+   (($f_list_equal f f_list_1 f_list_2)
+    (eo::and ($f_list_contains_f_list f f_list_1 f_list_2)
+             ($f_list_contains_f_list f f_list_2 f_list_1)))
+  )
+)
+
+; program: f_list_concat
+; args:
+; - f (-> A A A): Operator used to build the f-list.
+; - elem A: An element of type A.
+; - flist A: An f-list.
+; return: >
+;    Returns an f-list, with first operand "elem", followed by operands of flist_2.
+(define $f_list_cons ((A Type :implicit) (f (-> A A A)) (elem A)
+                     (tail A :list))
+    (f elem tail)
+)
+
+; program: f_list_remove_elem
+; args:
+; - list B: An f-list, where f is a variadic operator with some "nil" element.
+; - f_nil A: The "nil" element of variadic operator f.
+; - elem A: An element from "list" that we want to remove.
+; return: >
+;   Removes the first occurrence of "elem" in the given f-list. Returns
+;   the obtained f-list.
+(program $f_list_remove_elem ((A Type) (B Type)
+                             (f (-> A A B)) (f_nil A) (hd A) (tl A :list)
+                             (elem A))
+  ((-> A A B) B A A) B
+
+  (
+   (
+    ($f_list_remove_elem f (f elem tl) elem f_nil)
+    
+    tl
+    )
+
+   (; { hd =/= elem }
+    ($f_list_remove_elem f (f hd tl) elem f_nil)
+    
+    ($f_list_cons f hd ($f_list_remove_elem f tl elem f_nil))
+    )
+
+   (
+    ($f_list_remove_elem f elem elem f_nil)
+    
+    f_nil
+    )
+   
+   ; TODO: this should be an error
+   (; { hd =/= elem }
+    ($f_list_remove_elem f hd elem f_nil)
+    
+    hd
+    )
+   )
+  )
+
+; TODO: implement this as a higher-order program, once it becomes feasible
+; program: $f_list_filter
+; args:
+; - hd Bool:
+; - cl_tl Bool:
+; - varlist_tl @VarList:
+; return:
+(program $f_list_filter ((A Type) (f (-> A A A)) (nil_elem A)
+                         (hd A) (f_tl A :list) (varlist_tl @VarList :list))
+         ((-> A A A) A A @VarList) A
+         (
+          (
+           ($f_list_filter f nil_elem (f hd f_tl) (@varlist true varlist_tl))
+           ($f_list_filter f nil_elem f_tl varlist_tl)
+           )
+
+          (
+           ($f_list_filter f nil_elem (f hd f_tl) (@varlist false varlist_tl))
+           ($f_list_cons f
+                         hd
+                         ($f_list_filter f nil_elem f_tl varlist_tl))
+           )
+
+          (
+           ($f_list_filter f nil_elem hd (@varlist false @varlist.nil))
+           (f hd nil_elem)
+           )
+
+          (
+           ($f_list_filter f nil_elem hd (@varlist true @varlist.nil))
+           nil_elem 
+           )
+
+          (
+           ($f_list_filter f nil_elem nil_elem @varlist.nil)
+           nil_elem
+           )
+          )
+         )
+
+; program: $f_list_last_element
+; args:
+; - f (-> A A A): Operator used to build the f-list.
+; - f-list A: A non-empty f-list.
+; precondition: f-list is not empty.
+; return: Last element of f-list.
+(program $f_list_last_element ((A Type) (f (-> A A A))
+                               (hd A) (f_tl A :list))
+         ((-> A A A) A) A
+         (
+          (
+           ($f_list_last_element f nil_elem (f hd nil_elem))
+
+           hd
+           )
+
+          (
+           ($f_list_last_element f nil_elem (f hd f_tl))
+
+           ($f_list_last_element f nil_elem f_tl)
+           )
+
+          (; { hd is not an f-list }
+           ($f_list_last_element f nil_elem hd)
+
+           hd
+           )
+          )
+         )

--- a/signature/programs.eo
+++ b/signature/programs.eo
@@ -31,6 +31,120 @@
           )
 )
 
+;------------------------
+; Reflection mechanisms
+;------------------------
+
+; program: $is_theory_op_left_assoc
+; args:
+; - f (-> T U): A function constant.
+; return: >
+;    A boolean indicating if f is defined in our theory as 
+;    left-assoc/left-assoc-nil. It could receive a user defined function 
+;    constant, in which case the function will just return "false", regardless 
+;    of the actual associativity of f.
+(program $is_theory_op_left_assoc ((T Type) (U Type) (f (-> T U)))
+         :signature ((-> T U)) Bool
+         (
+          (
+           ($is_theory_op_left_assoc xor)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_left_assoc -)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_left_assoc /)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_left_assoc div)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_left_assoc f)
+           
+           false
+           )
+          )
+)
+
+; program: $is_theory_op_right_assoc
+; args:
+; - f (-> T U): A function constant.
+; return: >
+;    A boolean indicating if f is defined in our theory as 
+;    right-assoc/right-assoc-nil. It could receive a user defined function 
+;    constant, in which case the function will just return "false", regardless 
+;    of the actual associativity of f.
+(program $is_theory_op_right_assoc ((T Type) (U Type) (f (-> T U)))
+         :signature ((-> T U)) Bool
+         (
+          (
+           ($is_theory_op_right_assoc @cl)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_right_assoc or)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_right_assoc and)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_right_assoc =>)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_right_assoc +)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_right_assoc *)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_right_assoc @varlist)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_right_assoc @substitution)
+           
+           true
+           )
+
+          (
+           ($is_theory_op_right_assoc f)
+           
+           false
+           )
+          )
+)
+
 ;-------------
 ; @VarList
 ;-------------

--- a/signature/programs.eo
+++ b/signature/programs.eo
@@ -1,5 +1,5 @@
 (include "./theory.eo")
-(include "./f_lists.eo")
+(include "./lists.eo")
 
 ; Library of auxiliary programs, useful to manipulate many different
 ; Eunoia constructions.

--- a/signature/theory.eo
+++ b/signature/theory.eo
@@ -7,15 +7,16 @@
 ; TODO: some better way to deal with empty clauses?
 (declare-const @empty_cl Bool)
 
-
-(declare-const ite (-> (! Type :var A :implicit) Bool A A A))
+(declare-parameterized-const ite ((A Type :implicit)) (-> Bool A A A))
 (declare-const not (-> Bool Bool))
 (declare-const or (-> Bool Bool Bool) :right-assoc-nil false)
 (declare-const and (-> Bool Bool Bool) :right-assoc-nil true)
 (declare-const => (-> Bool Bool Bool) :right-assoc)
 (declare-const xor (-> Bool Bool Bool) :left-assoc)
-(declare-const = (-> (! Type :var A :implicit) A A Bool) :chainable and)
-(declare-const distinct (-> (! Type :var A :implicit) A A Bool) :pairwise and)
+(declare-parameterized-const = ((A Type :implicit)) (-> A A Bool) 
+                             :chainable and)
+(declare-parameterized-const distinct ((A Type :implicit)) (-> A A Bool) 
+                             :pairwise and)
 
 ; ---------------------------
 ;   Int and Real Arithmetic
@@ -63,58 +64,64 @@
 
 ; Core operators of arithmetic, which are used in mixed Int/Real arithmetic.
 ; Using integer nil terminators ensures typing is accurate.
-(declare-const + (-> (! Type :var T :implicit) (! Type :var U :implicit)
-                     T U ($arith_typeunion T U)) :right-assoc-nil 0)
-(declare-const - (-> (! Type :var T :implicit) (! Type :var U :implicit)
-                     T U ($arith_typeunion T U)) :left-assoc)
-(declare-const * (-> (! Type :var T :implicit) (! Type :var U :implicit)
-                     T U ($arith_typeunion T U)) :right-assoc-nil 1)
-(declare-const / (-> (! Type :var T :implicit) (! Type :var U :implicit)
-                     T U
-                     (! Real :requires (($is_arith_type T) true)
-                             :requires (($is_arith_type U) true))) :left-assoc)
+(declare-parameterized-const + ((T Type :implicit) (U Type :implicit))
+                             (-> T U ($arith_typeunion T U))
+                             :right-assoc-nil 0)
+(declare-parameterized-const - ((T Type :implicit) (U Type :implicit)) 
+                             (-> T U ($arith_typeunion T U)) :left-assoc)
+(declare-parameterized-const * ((T Type :implicit) (U Type :implicit)) 
+                             (-> T U ($arith_typeunion T U)) :right-assoc-nil 1)
+(declare-parameterized-const / ((T Type :implicit) (U Type :implicit))
+                             (-> T U ($arith_typeunion T U)) :left-assoc)
+
 (declare-const div (-> Int Int Int) :left-assoc)
 (declare-const mod (-> Int Int Int))
 
-(declare-const < (-> (! Type :var T :implicit) (! Type :var U :implicit)
-                     (! T :requires (($is_arith_type T) true))
-                     (! U :requires (($is_arith_type U) true))
-                     Bool)
-                     :chainable and)
-(declare-const <= (-> (! Type :var T :implicit) (! Type :var U :implicit)
-                      (! T :requires (($is_arith_type T) true))
-                      (! U :requires (($is_arith_type U) true))
-                      Bool)
-                      :chainable and)
-(declare-const > (-> (! Type :var T :implicit) (! Type :var U :implicit)
-                     (! T :requires (($is_arith_type T) true))
-                     (! U :requires (($is_arith_type U) true))
-                     Bool)
-                     :chainable and)
-(declare-const >= (-> (! Type :var T :implicit) (! Type :var U :implicit)
-                      (! T :requires (($is_arith_type T) true))
-                      (! U :requires (($is_arith_type U) true))
-                      Bool)
-                      :chainable and)
+; Currently unary negation cannot use overload.
+(declare-parameterized-const - ((T Type :implicit))
+                     (-> T (eo::requires ($is_arith_type T) true T)))
+
+; Orders
+(declare-parameterized-const < ((T Type :implicit) (U Type :implicit))
+                             (-> T U
+                                (eo::requires ($is_arith_type T) true
+                                              (eo::requires ($is_arith_type U) true
+                                                            Bool)))
+                             :chainable and)
+
+(declare-parameterized-const <= ((T Type :implicit) (U Type :implicit))
+                             (-> T U
+                                (eo::requires ($is_arith_type T) true
+                                              (eo::requires ($is_arith_type U) true
+                                                            Bool)))
+                             :chainable and)
+
+(declare-parameterized-const > ((T Type :implicit) (U Type :implicit))
+                             (-> T U
+                                (eo::requires ($is_arith_type T) true
+                                              (eo::requires ($is_arith_type U) true
+                                                            Bool)))
+                             :chainable and)
+
+(declare-parameterized-const >= ((T Type :implicit) (U Type :implicit))
+                             (-> T U
+                                (eo::requires ($is_arith_type T) true
+                                              (eo::requires ($is_arith_type U) true
+                                                            Bool)))
+                             :chainable and)
 
 ; Conversion functions.
-(declare-const to_real (-> (! Type :var T :implicit)
-                           (! T :requires (($is_arith_type T) true))
-                           Real))
-(declare-const to_int (-> (! Type :var T :implicit)
-                          (! T :requires (($is_arith_type T) true))
-                          Int))
-(declare-const is_int (-> (! Type :var T :implicit)
-                          (! T :requires (($is_arith_type T) true))
-                          Bool))
-(declare-const abs (-> (! Type :var T :implicit)
-                       (! T :requires (($is_arith_type T) true))
-                       T))
+(declare-parameterized-const to_real ((T Type :implicit))
+                           (-> T (eo::requires ($is_arith_type T) true Real)))
 
-; Currently unary negation cannot use overload.
-(declare-const - (-> (! Type :var T :implicit)
-                     (! T :requires (($is_arith_type T) true))
-                     T))
+(declare-parameterized-const to_int ((T Type :implicit))
+                           (-> T (eo::requires ($is_arith_type T) true Int)))
+
+(declare-parameterized-const is_int ((T Type :implicit))
+                           (-> T (eo::requires ($is_arith_type T) true Bool)))
+
+(declare-parameterized-const abs ((T Type :implicit))
+                           (-> T (eo::requires ($is_arith_type T) true T)))
 
 ; ---------------
 ;   Quantifiers
@@ -122,12 +129,13 @@
 
 (declare-type @VarList ())
 (declare-const @varlist.nil @VarList)
-(declare-const @varlist (-> (! Type :var T :implicit) T @VarList @VarList) :right-assoc-nil @varlist.nil)
+(declare-parameterized-const @varlist ((T Type :implicit)) 
+                             (-> T @VarList @VarList) :right-assoc-nil @varlist.nil)
 
 (declare-const forall (-> @VarList Bool Bool) :binder @varlist)
 (declare-const exists (-> @VarList Bool Bool) :binder @varlist)
-(declare-const choice (-> (! Type :var T :implicit) @VarList T Bool T) :binder @varlist)
-
+(declare-parameterized-const choice ((T Type :implicit))
+                             (-> T @VarList T Bool T) :binder @varlist)
 
 ; program: get_lambda_type
 ; args:
@@ -153,20 +161,15 @@
   )
 )
 
-(declare-const @let (-> (! Type :var B :implicit)
-                       (! @VarList :var L)
-                       B
-                       ($get_lambda_type L B)
-                       ) :binder @varlist)
-
+(declare-parameterized-const @let ((B Type :implicit) (L @VarList))
+                       (-> B ($get_lambda_type L B)) :binder @varlist)
 
 ; ------------
 ;   Contexts
 ; ------------
 
-(declare-const @ctx (-> (! @VarList :var L)
-                        Bool
-                        Bool) :binder @varlist)
+(declare-parameterized-const @ctx ((L @VarList))
+                        (-> Bool Bool) :binder @varlist)
 
 ; constant: @var
 ; type: (-> (! Type :var B :implicit)
@@ -176,9 +179,9 @@
 ; note: >
 ;    Represents an undefined inhabitant of a given type. 
 ;    Used to represent variables bound by some binder (including @ctx, forall, etc.)
-(declare-const @var (-> (! Type :var B :implicit) (! @VarList :var L) B B)
-               :binder @varlist)
-
+(declare-parameterized-const @var ((B Type :implicit) (L @VarList)) 
+                             (-> B B)
+                             :binder @varlist)
 ; ---------------
 ;   Substitutions
 ; ---------------
@@ -186,13 +189,14 @@
 ; Since some rules are defined directly in terms of a given substitution.
 ; Single substitute variable -> value
 (declare-type @Substitute ())
-(declare-const @substitute (-> (! Type  :var Var :implicit) (! Type  :var Value :implicit) 
-                              Var Value @Substitute))
+(declare-parameterized-const @substitute ((Var Type :implicit) 
+                                          (Value Type :implicit))
+                             (-> Var Value @Substitute))
 
 (declare-type @Substitution ())
 
 (declare-const @substitution.nil @Substitution)
 
-; TODO: I don't want for people to directly use this constructor
+; TODO: we don't want for the user to employ directly this constructor
 (declare-const @substitution (-> @Substitute @Substitution @Substitution)
                :right-assoc-nil @substitution.nil)


### PR DESCRIPTION
This pull-request only performs some cosmetic changes:
- removes program cases where assumptions are not embedded within a @cl (currently, assumptions are always embedded within a @cl, so those cases are not being used anymore).
- minor fixes in coding style, to adhere to a newer style being used across the mechanization.
- adding some missing docs. in programs.